### PR TITLE
Lab 3: Swagger UI, warstwa serwisowa, pełne CRUD i testy jednostkowe

### DIFF
--- a/Wojciech-Kapala/ProjectManagerApp/pom.xml
+++ b/Wojciech-Kapala/ProjectManagerApp/pom.xml
@@ -60,6 +60,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/Wojciech-Kapala/ProjectManagerApp/pom.xml
+++ b/Wojciech-Kapala/ProjectManagerApp/pom.xml
@@ -65,6 +65,11 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.5.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 
@@ -93,6 +98,26 @@
                         </exclude>
                     </excludes>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.10</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/ProjectController.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/ProjectController.java
@@ -52,4 +52,12 @@ public class ProjectController {
         projectService.deleteProject(id);
         return ResponseEntity.noContent().build();
     }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Get a project", description = "Retrieve a project by ID")
+    public Project getProjectById(
+            @Parameter(description = "ID of project to retrieve") @PathVariable Long id
+    ) {
+        return projectService.getProjectById(id);
+    }
 }

--- a/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/ProjectController.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/ProjectController.java
@@ -1,5 +1,8 @@
 package org.example.projectmanagerapp.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import org.example.projectmanagerapp.entity.Project;
 import org.example.projectmanagerapp.repository.ProjectRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,6 +11,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/projects")
+@Tag(name = "Projects", description = "Endpoints for managing projects")
 public class ProjectController {
 
     private final ProjectRepository projectRepository;
@@ -18,12 +22,14 @@ public class ProjectController {
     }
 
     @GetMapping
+    @Operation(summary = "Get all projects", description = "Retrieve a list of all projects")
     public List<Project> getAllProjects() {
         return projectRepository.findAll();
     }
 
     @PostMapping
-    public Project createProject(@RequestBody Project project) {
+    @Operation(summary = "Create a new project", description = "Create and save a new project")
+    public Project createProject(@Parameter(description = "Project entity to be created") @RequestBody Project project) {
         return projectRepository.save(project);
     }
 }

--- a/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/ProjectController.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/ProjectController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import org.example.projectmanagerapp.entity.Project;
-import org.example.projectmanagerapp.repository.ProjectRepository;
+import org.example.projectmanagerapp.service.ProjectService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
@@ -14,22 +14,23 @@ import java.util.List;
 @Tag(name = "Projects", description = "Endpoints for managing projects")
 public class ProjectController {
 
-    private final ProjectRepository projectRepository;
+    private final ProjectService projectService;
 
     @Autowired
-    public ProjectController(ProjectRepository projectRepository) {
-        this.projectRepository = projectRepository;
+    public ProjectController(ProjectService projectService) {
+        this.projectService = projectService;
     }
 
     @GetMapping
     @Operation(summary = "Get all projects", description = "Retrieve a list of all projects")
     public List<Project> getAllProjects() {
-        return projectRepository.findAll();
+        return projectService.getAllProjects();
     }
 
     @PostMapping
     @Operation(summary = "Create a new project", description = "Create and save a new project")
     public Project createProject(@Parameter(description = "Project entity to be created") @RequestBody Project project) {
-        return projectRepository.save(project);
+        return projectService.createProject(project);
+
     }
 }

--- a/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/ProjectController.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/ProjectController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import org.example.projectmanagerapp.entity.Project;
 import org.example.projectmanagerapp.service.ProjectService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
@@ -32,5 +33,23 @@ public class ProjectController {
     public Project createProject(@Parameter(description = "Project entity to be created") @RequestBody Project project) {
         return projectService.createProject(project);
 
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "Update a project", description = "Update project by ID")
+    public Project updateProject(
+            @Parameter(description = "ID of project to update") @PathVariable Long id,
+            @Parameter(description = "Updated project data") @RequestBody Project project
+    ) {
+        return projectService.updateProject(id, project);
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Delete a project", description = "Delete project by ID")
+    public ResponseEntity<Void> deleteProject(
+            @Parameter(description = "ID of project to delete") @PathVariable Long id
+    ) {
+        projectService.deleteProject(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/TaskController.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/TaskController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import org.example.projectmanagerapp.entity.Task;
 import org.example.projectmanagerapp.service.TaskService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
@@ -31,5 +32,23 @@ public class TaskController {
     @Operation(summary = "Create a new task", description = "Create and save a new task")
     public Task createTask(@Parameter(description = "Task entity to be created") @RequestBody Task task) {
         return taskService.createTask(task);
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "Update a task", description = "Update task by ID")
+    public Task updateTask(
+            @Parameter(description = "ID of task to update") @PathVariable Long id,
+            @Parameter(description = "Updated task data") @RequestBody Task task
+    ) {
+        return taskService.updateTask(id, task);
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Delete a task", description = "Delete task by ID")
+    public ResponseEntity<Void> deleteTask(
+            @Parameter(description = "ID of task to delete") @PathVariable Long id
+    ) {
+        taskService.deleteTask(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/TaskController.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/TaskController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import org.example.projectmanagerapp.entity.Task;
-import org.example.projectmanagerapp.repository.TaskRepository;
+import org.example.projectmanagerapp.service.TaskService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
@@ -14,22 +14,22 @@ import java.util.List;
 @Tag(name = "Tasks", description = "Endpoints for managing tasks")
 public class TaskController {
 
-    private final TaskRepository taskRepository;
+    private final TaskService taskService;
 
     @Autowired
-    public TaskController(TaskRepository taskRepository) {
-        this.taskRepository = taskRepository;
+    public TaskController(TaskService taskService) {
+        this.taskService = taskService;
     }
 
     @GetMapping
     @Operation(summary = "Get all tasks", description = "Retrieve a list of all tasks")
     public List<Task> getAllTasks() {
-        return taskRepository.findAll();
+        return taskService.getAllTasks();
     }
 
     @PostMapping
     @Operation(summary = "Create a new task", description = "Create and save a new task")
     public Task createTask(@Parameter(description = "Task entity to be created") @RequestBody Task task) {
-        return taskRepository.save(task);
+        return taskService.createTask(task);
     }
 }

--- a/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/TaskController.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/TaskController.java
@@ -1,5 +1,8 @@
 package org.example.projectmanagerapp.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import org.example.projectmanagerapp.entity.Task;
 import org.example.projectmanagerapp.repository.TaskRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,6 +11,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/tasks")
+@Tag(name = "Tasks", description = "Endpoints for managing tasks")
 public class TaskController {
 
     private final TaskRepository taskRepository;
@@ -18,12 +22,14 @@ public class TaskController {
     }
 
     @GetMapping
+    @Operation(summary = "Get all tasks", description = "Retrieve a list of all tasks")
     public List<Task> getAllTasks() {
         return taskRepository.findAll();
     }
 
     @PostMapping
-    public Task createTask(@RequestBody Task task) {
+    @Operation(summary = "Create a new task", description = "Create and save a new task")
+    public Task createTask(@Parameter(description = "Task entity to be created") @RequestBody Task task) {
         return taskRepository.save(task);
     }
 }

--- a/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/TaskController.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/TaskController.java
@@ -51,4 +51,12 @@ public class TaskController {
         taskService.deleteTask(id);
         return ResponseEntity.noContent().build();
     }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Get a task", description = "Retrieve a task by ID")
+    public Task getTaskById(
+            @Parameter(description = "ID of task to retrieve") @PathVariable Long id
+    ) {
+        return taskService.getTaskById(id);
+    }
 }

--- a/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/UserController.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/UserController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import org.example.projectmanagerapp.entity.User;
-import org.example.projectmanagerapp.repository.UserRepository;
+import org.example.projectmanagerapp.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
@@ -14,22 +14,22 @@ import java.util.List;
 @Tag(name = "Users", description = "Endpoints for managing users")
 public class UserController {
 
-    private final UserRepository userRepository;
+    private final UserService userService;
 
     @Autowired
-    public UserController(UserRepository userRepository) {
-        this.userRepository = userRepository;
+    public UserController(UserService userService) {
+        this.userService = userService;
     }
 
     @GetMapping
     @Operation(summary = "Get all users", description = "Retrieve a list of all users")
     public List<User> getAllUsers() {
-        return userRepository.findAll();
+        return userService.getAllUsers();
     }
 
     @PostMapping
     @Operation(summary = "Create a new user", description = "Create and save a new user")
-    public User createUser( @Parameter(description = "User entity to be created") @RequestBody User user) {
-        return userRepository.save(user);
+    public User createUser(@Parameter(description = "User entity to be created") @RequestBody User user) {
+        return userService.createUser(user);
     }
 }

--- a/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/UserController.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/UserController.java
@@ -1,5 +1,8 @@
 package org.example.projectmanagerapp.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import org.example.projectmanagerapp.entity.User;
 import org.example.projectmanagerapp.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,6 +11,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/users")
+@Tag(name = "Users", description = "Endpoints for managing users")
 public class UserController {
 
     private final UserRepository userRepository;
@@ -18,12 +22,14 @@ public class UserController {
     }
 
     @GetMapping
+    @Operation(summary = "Get all users", description = "Retrieve a list of all users")
     public List<User> getAllUsers() {
         return userRepository.findAll();
     }
 
     @PostMapping
-    public User createUser(@RequestBody User user) {
+    @Operation(summary = "Create a new user", description = "Create and save a new user")
+    public User createUser( @Parameter(description = "User entity to be created") @RequestBody User user) {
         return userRepository.save(user);
     }
 }

--- a/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/UserController.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/UserController.java
@@ -51,4 +51,12 @@ public class UserController {
         userService.deleteUser(id);
         return ResponseEntity.noContent().build();
     }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Get a user", description = "Retrieve a user by ID")
+    public User getUserById(
+            @Parameter(description = "ID of user to retrieve") @PathVariable Long id
+    ) {
+        return userService.getUserById(id);
+    }
 }

--- a/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/UserController.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/controller/UserController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import org.example.projectmanagerapp.entity.User;
 import org.example.projectmanagerapp.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
@@ -31,5 +32,23 @@ public class UserController {
     @Operation(summary = "Create a new user", description = "Create and save a new user")
     public User createUser(@Parameter(description = "User entity to be created") @RequestBody User user) {
         return userService.createUser(user);
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "Update a user", description = "Update user by ID")
+    public User updateUser(
+            @Parameter(description = "ID of user to update") @PathVariable Long id,
+            @Parameter(description = "Updated user data") @RequestBody User dto
+    ) {
+        return userService.updateUser(id, dto);
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Delete a user", description = "Delete user by ID")
+    public ResponseEntity<Void> deleteUser(
+            @Parameter(description = "ID of user to delete") @PathVariable Long id
+    ) {
+        userService.deleteUser(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/service/ProjectService.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/service/ProjectService.java
@@ -1,0 +1,27 @@
+package org.example.projectmanagerapp.service;
+
+import org.example.projectmanagerapp.entity.Project;
+import org.example.projectmanagerapp.repository.ProjectRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ProjectService {
+
+    private final ProjectRepository projectRepository;
+
+    @Autowired
+    public ProjectService(ProjectRepository projectRepository) {
+        this.projectRepository = projectRepository;
+    }
+
+    public List<Project> getAllProjects() {
+        return projectRepository.findAll();
+    }
+
+    public Project createProject(Project project) {
+        return projectRepository.save(project);
+    }
+}

--- a/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/service/ProjectService.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/service/ProjectService.java
@@ -38,4 +38,9 @@ public class ProjectService {
     public void deleteProject(Long id) {
         projectRepository.deleteById(id);
     }
+
+    public Project getProjectById(Long id) {
+        return projectRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Project not found: " + id));
+    }
 }

--- a/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/service/ProjectService.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/service/ProjectService.java
@@ -24,4 +24,18 @@ public class ProjectService {
     public Project createProject(Project project) {
         return projectRepository.save(project);
     }
+
+    public Project updateProject(Long id, Project dto) {
+        Project existing = projectRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Project not found: " + id));
+        existing.setName(dto.getName());
+        // jeśli masz inne pola do aktualizacji, dopisz je tutaj, np.:
+        // existing.setUsers(dto.getUsers());
+        // existing.setTasks(dto.getTasks());
+        return projectRepository.save(existing);
+    }
+
+    public void deleteProject(Long id) {
+        projectRepository.deleteById(id);
+    }
 }

--- a/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/service/TaskService.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/service/TaskService.java
@@ -1,0 +1,27 @@
+package org.example.projectmanagerapp.service;
+
+import org.example.projectmanagerapp.entity.Task;
+import org.example.projectmanagerapp.repository.TaskRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class TaskService {
+
+    private final TaskRepository taskRepository;
+
+    @Autowired
+    public TaskService(TaskRepository taskRepository) {
+        this.taskRepository = taskRepository;
+    }
+
+    public List<Task> getAllTasks() {
+        return taskRepository.findAll();
+    }
+
+    public Task createTask(Task task) {
+        return taskRepository.save(task);
+    }
+}

--- a/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/service/TaskService.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/service/TaskService.java
@@ -39,4 +39,9 @@ public class TaskService {
     public void deleteTask(Long id) {
         taskRepository.deleteById(id);
     }
+
+    public Task getTaskById(Long id) {
+        return taskRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Task not found: " + id));
+    }
 }

--- a/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/service/TaskService.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/service/TaskService.java
@@ -1,6 +1,7 @@
 package org.example.projectmanagerapp.service;
 
 import org.example.projectmanagerapp.entity.Task;
+import org.example.projectmanagerapp.entity.User;
 import org.example.projectmanagerapp.repository.TaskRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -23,5 +24,19 @@ public class TaskService {
 
     public Task createTask(Task task) {
         return taskRepository.save(task);
+    }
+
+    public Task updateTask(Long id, Task dto) {
+        Task existing = taskRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Task not found: " + id));
+        existing.setTitle(dto.getTitle());
+        existing.setDescription(dto.getDescription());
+        existing.setTaskType(dto.getTaskType());
+        existing.setProject(dto.getProject());
+        return taskRepository.save(existing);
+    }
+
+    public void deleteTask(Long id) {
+        taskRepository.deleteById(id);
     }
 }

--- a/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/service/UserService.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/service/UserService.java
@@ -1,0 +1,27 @@
+package org.example.projectmanagerapp.service;
+
+import org.example.projectmanagerapp.entity.User;
+import org.example.projectmanagerapp.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Autowired
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public List<User> getAllUsers() {
+        return userRepository.findAll();
+    }
+
+    public User createUser(User user) {
+        return userRepository.save(user);
+    }
+}

--- a/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/service/UserService.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/service/UserService.java
@@ -35,4 +35,9 @@ public class UserService {
     public void deleteUser(Long id) {
         userRepository.deleteById(id);
     }
+
+    public User getUserById(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("User not found: " + id));
+    }
 }

--- a/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/service/UserService.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/main/java/org/example/projectmanagerapp/service/UserService.java
@@ -24,4 +24,15 @@ public class UserService {
     public User createUser(User user) {
         return userRepository.save(user);
     }
+
+    public User updateUser(Long id, User dto) {
+        User existing = userRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("User not found: " + id));
+        existing.setUsername(dto.getUsername());
+        return userRepository.save(existing);
+    }
+
+    public void deleteUser(Long id) {
+        userRepository.deleteById(id);
+    }
 }

--- a/Wojciech-Kapala/ProjectManagerApp/src/test/java/org/example/projectmanagerapp/service/ProjectServiceTest.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/test/java/org/example/projectmanagerapp/service/ProjectServiceTest.java
@@ -1,0 +1,86 @@
+package org.example.projectmanagerapp.service;
+
+import org.example.projectmanagerapp.entity.Project;
+import org.example.projectmanagerapp.repository.ProjectRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ProjectServiceTest {
+
+    private ProjectRepository projectRepository;
+    private ProjectService projectService;
+
+    @BeforeEach
+    void setUp() {
+        projectRepository = Mockito.mock(ProjectRepository.class);
+        projectService = new ProjectService(projectRepository);
+    }
+
+    @Test
+    @DisplayName("Should return all projects")
+    void testGetAllProjects() {
+        Project p1 = new Project(); p1.setName("P1");
+        Project p2 = new Project(); p2.setName("P2");
+        when(projectRepository.findAll()).thenReturn(Arrays.asList(p1, p2));
+
+        List<Project> res = projectService.getAllProjects();
+
+        assertEquals(2, res.size());
+        verify(projectRepository, times(1)).findAll();
+    }
+
+    @Test
+    @DisplayName("Should get project by ID")
+    void testGetProjectById() {
+        Project p = new Project(); p.setId(10L); p.setName("X");
+        when(projectRepository.findById(10L)).thenReturn(Optional.of(p));
+
+        Project res = projectService.getProjectById(10L);
+
+        assertEquals("X", res.getName());
+        verify(projectRepository).findById(10L);
+    }
+
+    @Test
+    @DisplayName("Should create project")
+    void testCreateProject() {
+        Project p = new Project(); p.setName("New");
+        when(projectRepository.save(p)).thenReturn(p);
+
+        Project res = projectService.createProject(p);
+
+        assertSame(p, res);
+        verify(projectRepository).save(p);
+    }
+
+    @Test
+    @DisplayName("Should update project")
+    void testUpdateProject() {
+        Project existing = new Project(); existing.setId(5L); existing.setName("Old");
+        Project dto      = new Project(); dto.setName("New");
+        when(projectRepository.findById(5L)).thenReturn(Optional.of(existing));
+        when(projectRepository.save(existing)).thenReturn(existing);
+
+        Project res = projectService.updateProject(5L, dto);
+
+        assertEquals("New", res.getName());
+        verify(projectRepository).findById(5L);
+        verify(projectRepository).save(existing);
+    }
+
+    @Test
+    @DisplayName("Should delete project")
+    void testDeleteProject() {
+        doNothing().when(projectRepository).deleteById(7L);
+        projectService.deleteProject(7L);
+        verify(projectRepository).deleteById(7L);
+    }
+}

--- a/Wojciech-Kapala/ProjectManagerApp/src/test/java/org/example/projectmanagerapp/service/TaskServiceTest.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/test/java/org/example/projectmanagerapp/service/TaskServiceTest.java
@@ -1,0 +1,89 @@
+package org.example.projectmanagerapp.service;
+
+import org.example.projectmanagerapp.entity.Task;
+import org.example.projectmanagerapp.entity.Project;
+import org.example.projectmanagerapp.repository.TaskRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class TaskServiceTest {
+
+    private TaskRepository taskRepository;
+    private TaskService taskService;
+
+    @BeforeEach
+    void setUp() {
+        taskRepository = Mockito.mock(TaskRepository.class);
+        taskService = new TaskService(taskRepository);
+    }
+
+    @Test
+    @DisplayName("Should return all tasks")
+    void testGetAllTasks() {
+        Task t1 = new Task(); t1.setTitle("T1");
+        Task t2 = new Task(); t2.setTitle("T2");
+        when(taskRepository.findAll()).thenReturn(Arrays.asList(t1, t2));
+
+        List<Task> res = taskService.getAllTasks();
+
+        assertEquals(2, res.size());
+        verify(taskRepository).findAll();
+    }
+
+    @Test
+    @DisplayName("Should get task by ID")
+    void testGetTaskById() {
+        Task t = new Task(); t.setId(3L); t.setTitle("X");
+        when(taskRepository.findById(3L)).thenReturn(Optional.of(t));
+
+        Task res = taskService.getTaskById(3L);
+
+        assertEquals("X", res.getTitle());
+        verify(taskRepository).findById(3L);
+    }
+
+    @Test
+    @DisplayName("Should create task")
+    void testCreateTask() {
+        Task t = new Task(); t.setTitle("New");
+        when(taskRepository.save(t)).thenReturn(t);
+
+        Task res = taskService.createTask(t);
+
+        assertSame(t, res);
+        verify(taskRepository).save(t);
+    }
+
+    @Test
+    @DisplayName("Should update task")
+    void testUpdateTask() {
+        Project p = new Project(); p.setId(1L);
+        Task existing = new Task(); existing.setId(4L);
+        existing.setTitle("Old"); existing.setProject(p);
+        Task dto      = new Task(); dto.setTitle("New"); dto.setProject(p);
+        when(taskRepository.findById(4L)).thenReturn(Optional.of(existing));
+        when(taskRepository.save(existing)).thenReturn(existing);
+
+        Task res = taskService.updateTask(4L, dto);
+
+        assertEquals("New", res.getTitle());
+        verify(taskRepository).findById(4L);
+        verify(taskRepository).save(existing);
+    }
+
+    @Test
+    @DisplayName("Should delete task")
+    void testDeleteTask() {
+        doNothing().when(taskRepository).deleteById(8L);
+        taskService.deleteTask(8L);
+        verify(taskRepository).deleteById(8L);
+    }
+}

--- a/Wojciech-Kapala/ProjectManagerApp/src/test/java/org/example/projectmanagerapp/service/UserServiceTest.java
+++ b/Wojciech-Kapala/ProjectManagerApp/src/test/java/org/example/projectmanagerapp/service/UserServiceTest.java
@@ -1,0 +1,93 @@
+package org.example.projectmanagerapp.service;
+
+import org.example.projectmanagerapp.entity.User;
+import org.example.projectmanagerapp.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class UserServiceTest {
+
+    private UserRepository userRepository;
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = Mockito.mock(UserRepository.class);
+        userService = new UserService(userRepository);
+    }
+
+    @Test
+    @DisplayName("Should return all users")
+    void testGetAllUsers() {
+        User u1 = new User(); u1.setUsername("A");
+        User u2 = new User(); u2.setUsername("B");
+        when(userRepository.findAll()).thenReturn(Arrays.asList(u1, u2));
+
+        List<User> result = userService.getAllUsers();
+
+        assertEquals(2, result.size());
+        verify(userRepository, times(1)).findAll();
+    }
+
+    @Test
+    @DisplayName("Should find user by ID")
+    void testGetUserById() {
+        User u = new User(); u.setId(5L); u.setUsername("X");
+        when(userRepository.findById(5L)).thenReturn(Optional.of(u));
+
+        User result = userService.getUserById(5L);
+
+        assertEquals("X", result.getUsername());
+        verify(userRepository, times(1)).findById(5L);
+    }
+
+    @Test
+    @DisplayName("Should throw when user not found by ID")
+    void testGetUserByIdNotFound() {
+        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+        assertThrows(RuntimeException.class, () -> userService.getUserById(1L));
+    }
+
+    @Test
+    @DisplayName("Should create user")
+    void testCreateUser() {
+        User u = new User(); u.setUsername("New");
+        when(userRepository.save(u)).thenReturn(u);
+
+        User result = userService.createUser(u);
+
+        assertSame(u, result);
+        verify(userRepository, times(1)).save(u);
+    }
+
+    @Test
+    @DisplayName("Should update existing user")
+    void testUpdateUser() {
+        User existing = new User(); existing.setId(2L); existing.setUsername("Old");
+        User dto      = new User(); dto.setUsername("New");
+        when(userRepository.findById(2L)).thenReturn(Optional.of(existing));
+        when(userRepository.save(existing)).thenReturn(existing);
+
+        User result = userService.updateUser(2L, dto);
+
+        assertEquals("New", result.getUsername());
+        verify(userRepository).findById(2L);
+        verify(userRepository).save(existing);
+    }
+
+    @Test
+    @DisplayName("Should delete user")
+    void testDeleteUser() {
+        doNothing().when(userRepository).deleteById(3L);
+        userService.deleteUser(3L);
+        verify(userRepository, times(1)).deleteById(3L);
+    }
+}


### PR DESCRIPTION
W ramach zadania Lab 3 wprowadziłem następujące modyfikacje:

1. **Synchronizacja z upstream & nowa gałąź**

   * `git fetch upstream` + `git merge upstream/main` przed rozpoczęciem.
   * Utworzona gałąź `wojciech-kapala-lab-3`.

2. **Integracja Swagger/OpenAPI**

   * Dodana zależność `springdoc-openapi-starter-webmvc-ui` w `pom.xml`.
   * Oznaczenie kontrolerów (`@Tag`, `@Operation`, `@Parameter`) dla zasobów **Users**, **Projects**, **Tasks**.
   * Zweryfikowane działanie w Swagger UI pod adresem `http://localhost:8080/swagger-ui.html`.

3. **Warstwa serwisowa**

   * Utworzone klasy `UserService`, `ProjectService`, `TaskService` do logiki biznesowej.
   * Przerobione kontrolery, aby korzystały z serwisów zamiast bezpośrednio z repozytoriów.

4. **Pełne CRUD**

   * **POST** `/api/{users|projects|tasks}` – tworzenie.
   * **GET** `/api/{resources}` – lista wszystkich.
   * **GET** `/api/{resources}/{id}` – pobranie po ID.
   * **PUT** `/api/{resources}/{id}` – aktualizacja po ID.
   * **DELETE** `/api/{resources}/{id}` – usunięcie po ID.
   * Wszystkie endpointy udokumentowane adnotacjami Swaggera.

5. **Testy jednostkowe i pokrycie**

   * Dodana zależność `spring-boot-starter-test`.
   * Napisane testy JUnit5 + Mockito dla serwisów (`getAll`, `getById`, `create`, `update`, `delete`).
   * Skonfigurowany plugin JaCoCo (wersja 0.8.10), generowany raport w `target/site/jacoco/index.html`.
   * Pokrycie kodu serwisowego ≥ 80 %.